### PR TITLE
net5.0-windows>net6.0-windows, dpack 2.1.7>2.1.8

### DIFF
--- a/SkipCutscene/SkipCutscene.csproj
+++ b/SkipCutscene/SkipCutscene.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net5.0-windows</TargetFramework>
+    <TargetFramework>net6.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <PlatformTarget>x64</PlatformTarget>
     <Platforms>x64;AnyCPU</Platforms>
@@ -16,6 +16,6 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.7" />
+    <PackageReference Include="DalamudPackager" Version="2.1.8" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
dalamud uses net6 as of 6.2/API7, plugin functions once 5 changed to 6